### PR TITLE
Change the tree parsing logic to avoid copying bytes

### DIFF
--- a/src/git_parsing.rs
+++ b/src/git_parsing.rs
@@ -55,6 +55,7 @@ pub fn parse_object(data: &[u8]) -> Result<GitObject> {
             let mut hashes = vec![];
 
             let decompressed = split_object_at_zero(decompressed)?;
+            let chunk_size = 0x14;
 
             // TODO: this is still ugly, use a more elegant approach instead
             let mut decompressed_iter = decompressed.iter().enumerate();
@@ -65,12 +66,12 @@ pub fn parse_object(data: &[u8]) -> Result<GitObject> {
                 .next()
             {
                 // slice the array instead of cloning the bytes
-                let end = std::cmp::min(offset + 0x14, decompressed.len());
+                let end = std::cmp::min(offset + chunk_size, decompressed.len());
                 let bytes = &decompressed[offset..end];
                 hashes.push(slice_to_hex(bytes));
 
                 (&mut decompressed_iter)
-                    .skip(0x14 - 2)
+                    .skip(chunk_size - 2)
                     // this next() consumes the last chunk element from the iterator
                     .next();
                 // thus, we skip over the remaining (chunk - 2) bytes in between

--- a/src/git_parsing.rs
+++ b/src/git_parsing.rs
@@ -59,21 +59,17 @@ pub fn parse_object(data: &[u8]) -> Result<GitObject> {
 
             // TODO: this is still ugly, use a more elegant approach instead
             let mut decompressed_iter = decompressed.iter().enumerate();
-            while let Some((offset, _)) = (&mut decompressed_iter)
-                .skip_while(|(_, &b)| b != 0)
-                .skip(1)
-                // this next() consumes the first chunk element from the iterator
-                .next()
+            while let Some((offset, _)) =
+                (&mut decompressed_iter).skip_while(|(_, &b)| b != 0).nth(1)
+            // this nth() consumes the first chunk element from the iterator
             {
                 // slice the array instead of cloning the bytes
                 let end = std::cmp::min(offset + chunk_size, decompressed.len());
                 let bytes = &decompressed[offset..end];
                 hashes.push(slice_to_hex(bytes));
 
-                (&mut decompressed_iter)
-                    .skip(chunk_size - 2)
-                    // this next() consumes the last chunk element from the iterator
-                    .next();
+                decompressed_iter.nth(chunk_size - 2);
+                // this nth() consumes the last chunk element from the iterator
                 // thus, we skip over the remaining (chunk - 2) bytes in between
             }
 


### PR DESCRIPTION
### Changes:
- While parsing heads, do not create a reference and then immediately dereference them.
- Instead of using the `take` and `clone` methods while parsing the decompressed bytes of a tree object, we simply find the respective starting and ending offsets and pass a reference to that slice of the array to the `slice_to_hex` function.
- Use `position` method for an iterator instead of chaining `find` and `map` when we are only concerned with the index.